### PR TITLE
Update match rules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = {
                 version: packageJson.version,
                 author: "Mio.",
                 // licence: "GPL3",
-                match: ["*://www.mydramalist.com/*", "*mydramalist.com/*"],
+                match: ["*://*.mydramalist.com/*"],
                 description: "A userscript to enhance the website by making it more friendly & modern",
                 downloadURL: "https://github.com/dear-clouds/better-mdl/raw/main/better-mdl.user.js",
                 updateURL: "https://github.com/dear-clouds/better-mdl/raw/main/better-mdl.meta.js",


### PR DESCRIPTION
"*mydramalist.com/*" is not valid match syntax:

```
<url-pattern> := <scheme>://<host><path>
<scheme> := '*' | 'http' | 'https' | 'file' | 'ftp' | 'urn'
<host> := '*' | '*.' <any char except '/' and '*'>+
<path> := '/' <any chars>
```

https://developer.chrome.com/docs/extensions/mv2/match-patterns https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns

----

Off-topic curious, did you not add "my" style of highlighting the entire row for a drama/movie because you find it too intrusive?
![image](https://github.com/user-attachments/assets/df6906c7-7ea2-4064-9e03-3d167a924e61)
